### PR TITLE
Fix typos and grammar issues in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
                                 processing, color management, and high-performance optimization.
                             </p>
                             <p>
-                                With nearly 20 years of programming experience, and active
+                                With nearly 20 years of programming experience and active
                                 participation in the open source multimedia community, I bring deep
                                 technical expertise and a proven track record of solving complex
                                 problems in video processing, color management, and high-performance
@@ -121,7 +121,7 @@
                         <div class="service-icon">✨</div>
                         <h3>Feature Development</h3>
                         <p>
-                            Design and implementation of new features, including implemementation of new standards,
+                            Design and implementation of new features, including implementation of new standards,
                             codecs or filters, from concept through production-ready code.
                         </p>
                     </div>
@@ -222,7 +222,7 @@
                         <h3>Multimedia Processing</h3>
                         <p>
                             Video and audio codecs, processing algorithms, and filtering pipelines. Familiar with both
-                            traditional DSP and neural network based approaches.
+                            traditional DSP and neural network-based approaches.
                         </p>
                         <div class="skill-tags">
                             <span class="skill-tag">Codec Design</span>
@@ -281,7 +281,7 @@
                         <h3>libplacebo</h3>
                         <p class="project-role">Author & Maintainer</p>
                         <p>
-                            Reusable cross-platform library for GPU-accelerated realtime image and video processing.
+                            Reusable cross-platform library for GPU-accelerated real-time image and video processing.
                             Features the world's most feature-complete open source GPU color management pipeline,
                             including dynamic tone mapping with on-the-fly frame analysis, GPU film grain synthesis,
                             high-quality scaling and filtering, and more. Used in mpv, VLC and FFmpeg.
@@ -314,7 +314,7 @@
                         <h3>dav1d</h3>
                         <p class="project-role">Developer</p>
                         <p>
-                            Development of an experimental GPU-based Vulkan decoder using compute shaders, as well other
+                            Development of an experimental GPU-based Vulkan decoder using compute shaders, as well as other
                             contributions including film grain synthesis and RISC-V SIMD routines.
                         </p>
                     </div>


### PR DESCRIPTION
- Fix typo: "implemementation" → "implementation" (line 124)
- Fix typo: "as well other" → "as well as other" (line 317)
- Fix grammar: Remove awkward comma in compound subject (line 72)
- Fix grammar: Add hyphen to "neural network-based" (line 225)
- Fix grammar: Hyphenate "realtime" → "real-time" when used as adjective (line 284)