### PR TITLE
Add project links to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,10 +77,10 @@
                             </p>
                             <p>
                                 I am a regular and active contributor to industry-leading projects including
-                                <strong><a href="https://ffmpeg.org/" target="_blank" rel="noopener noreferrer">FFmpeg</a></strong>, <strong><a href="https://code.videolan.org/videolan/dav1d" target="_blank" rel="noopener noreferrer">dav1d</a></strong>, <strong>VLC</strong> and
+                                <strong><a href="https://ffmpeg.org/" target="_blank" rel="noopener noreferrer">FFmpeg</a></strong>, <strong><a href="https://code.videolan.org/videolan/dav1d" target="_blank" rel="noopener noreferrer">dav1d</a></strong>, <strong><a href="https://www.videolan.org/" target="_blank" rel="noopener noreferrer">VLC</a></strong> and
                                 <strong><a href="https://mpv.io/" target="_blank" rel="noopener noreferrer">mpv</a></strong>, where I focus on advancing the state of the art in
                                 multimedia processing and playback. I am a member of the <strong><a href="https://ffmpeg.org/" target="_blank" rel="noopener noreferrer">FFmpeg</a></strong>
-                                and <strong>VideoLAN</strong> technical committees, as well as the
+                                and <strong><a href="https://www.videolan.org/" target="_blank" rel="noopener noreferrer">VideoLAN</a></strong> technical committees, as well as the
                                 maintainer of <strong><a href="https://libplacebo.org/" target="_blank" rel="noopener noreferrer">libplacebo</a></strong> and <strong><a href="https://code.videolan.org/videolan/checkasm" target="_blank" rel="noopener noreferrer">checkasm</a></strong>.
                             </p>
                         </div>
@@ -284,7 +284,7 @@
                             Reusable cross-platform library for GPU-accelerated real-time image and video processing.
                             Features the world's most feature-complete open source GPU color management pipeline,
                             including dynamic tone mapping with on-the-fly frame analysis, GPU film grain synthesis,
-                            high-quality scaling and filtering, and more. Used in <a href="https://mpv.io/" target="_blank" rel="noopener noreferrer">mpv</a>, VLC and <a href="https://ffmpeg.org/" target="_blank" rel="noopener noreferrer">FFmpeg</a>.
+                            high-quality scaling and filtering, and more. Used in <a href="https://mpv.io/" target="_blank" rel="noopener noreferrer">mpv</a>, <a href="https://www.videolan.org/" target="_blank" rel="noopener noreferrer">VLC</a> and <a href="https://ffmpeg.org/" target="_blank" rel="noopener noreferrer">FFmpeg</a>.
                         </p>
                     </div>
 


### PR DESCRIPTION
- Added links to libplacebo (https://libplacebo.org/)
- Added links to dav1d (https://code.videolan.org/videolan/dav1d)
- Added links to FFmpeg (https://ffmpeg.org/)
- Added links to mpv (https://mpv.io/)
- Added links to checkasm (https://code.videolan.org/videolan/checkasm)

Links added in both the About section and individual project cards.