### PR TITLE
Hide theme toggle on mobile devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -653,6 +653,11 @@ footer a:hover {
         gap: 1rem;
     }
 
+    /* Hide theme toggle on mobile devices */
+    .theme-toggle {
+        display: none;
+    }
+
     #hero h1 {
         font-size: 2rem;
     }


### PR DESCRIPTION
Add CSS media query to hide the light/dark theme toggle on screens
768px and smaller to prevent it from breaking to a new line on mobile.
The toggle will only be visible on desktop browsers.