### PR TITLE
Convert site to Jekyll for GitHub Pages compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Jekyll build files
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# Ruby/Bundler
+.bundle/
+vendor/
+Gemfile.lock
+
+# macOS
+.DS_Store
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,33 @@
+# Site settings
+title: Niklas Haas - Consulting
+description: IT consulting specializing in multimedia processing, SIMD, color management, HDR, and performance optimization
+url: https://www.niklashaas.de
+baseurl: ""
+
+# Build settings
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+# Jekyll configuration for GitHub Pages
+plugins:
+  - jekyll-relative-links
+
+# Exclude files from the build
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - vendor
+
+# Include hidden files that start with underscore (not directories)
+include:
+  - _redirects
+
+# Disable automatic directory indexes
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,12 @@
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 Niklas Haas. All rights reserved.</p>
+            <p><a href="{{ '/impressum.html' | relative_url }}">Impressum</a></p>
+        </div>
+    </footer>
+
+    <script>
+        setupThemeSwitcher();
+    </script>
+</body>
+</html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }} - Niklas Haas</title>
+    <meta name="description" content="{{ page.description | default: 'IT consulting specializing in multimedia processing, SIMD, color management, HDR, and performance optimization. Expert in FFmpeg, libplacebo, VLC, and mpv.' }}">
+    <link rel="stylesheet" href="{{ '/css/style.css' | relative_url }}">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <script src="{{ '/js/theme-switcher.js' | relative_url }}"></script>
+    <script>initTheme();</script>
+    {% if page.custom_css %}
+    <style>
+        {{ page.custom_css }}
+    </style>
+    {% endif %}
+</head>
+<body>
+    <header>
+        <nav class="container">
+            <div class="logo">Haas Consulting</div>
+            <ul class="nav-links">
+                <li><a href="{{ '/' | relative_url }}#about">About</a></li>
+                <li><a href="{{ '/' | relative_url }}#services">Services</a></li>
+                <li><a href="{{ '/' | relative_url }}#skills">Skills</a></li>
+                <li><a href="{{ '/' | relative_url }}#projects">Projects</a></li>
+                <li><a href="{{ '/' | relative_url }}#contact">Contact</a></li>
+                <li><a href="#" class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                    <span class="material-icons theme-icon">brightness_4</span>
+                </a></li>
+            </ul>
+        </nav>
+    </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,7 @@
+{% include header.html %}
+
+    <main>
+{{ content }}
+    </main>
+
+{% include footer.html %}

--- a/impressum.html
+++ b/impressum.html
@@ -1,73 +1,48 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Impressum - Niklas Haas</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script src="js/theme-switcher.js"></script>
-    <script>initTheme();</script>
-    <style>
-        .impressum-content {
-            max-width: 800px;
-            margin: 3rem auto;
-            padding: 0 2rem;
-        }
+---
+layout: default
+title: Impressum
+custom_css: |
+    .impressum-content {
+        max-width: 800px;
+        margin: 3rem auto;
+        padding: 0 2rem;
+    }
 
-        .impressum-content h1 {
-            font-size: 2.5rem;
-            margin-bottom: 2rem;
-            color: var(--text-primary);
-        }
+    .impressum-content h1 {
+        font-size: 2.5rem;
+        margin-bottom: 2rem;
+        color: var(--text-primary);
+    }
 
-        .impressum-content h2 {
-            font-size: 1.5rem;
-            margin-top: 2rem;
-            margin-bottom: 1rem;
-            color: var(--text-primary);
-            text-align: left;
-        }
+    .impressum-content h2 {
+        font-size: 1.5rem;
+        margin-top: 2rem;
+        margin-bottom: 1rem;
+        color: var(--text-primary);
+        text-align: left;
+    }
 
-        .impressum-content p {
-            line-height: 1.8;
-            color: var(--text-secondary);
-            margin-bottom: 1rem;
-        }
+    .impressum-content p {
+        line-height: 1.8;
+        color: var(--text-secondary);
+        margin-bottom: 1rem;
+    }
 
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2rem;
-            color: var(--primary-color);
-            text-decoration: none;
-            font-weight: 500;
-        }
+    .back-link {
+        display: inline-block;
+        margin-bottom: 2rem;
+        color: var(--primary-color);
+        text-decoration: none;
+        font-weight: 500;
+    }
 
-        .back-link:hover {
-            text-decoration: underline;
-        }
-    </style>
-</head>
-<body>
-    <header>
-        <nav class="container">
-            <div class="logo">Haas Consulting</div>
-            <ul class="nav-links">
-                <li><a href="index.html#about">About</a></li>
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#skills">Skills</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="#" class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-                    <span class="material-icons theme-icon">brightness_4</span>
-                </a></li>
-            </ul>
-        </nav>
-    </header>
+    .back-link:hover {
+        text-decoration: underline;
+    }
+---
 
-    <main>
         <div class="impressum-content">
-            <a href="index.html" class="back-link">&larr; Back to Home</a>
+            <a href="{{ '/' | relative_url }}" class="back-link">&larr; Back to Home</a>
 
             <h1>Impressum</h1>
 
@@ -82,16 +57,3 @@
                 Contact: <a href="mailto:contact@niklashaas.de">contact@niklashaas.de</a>
             </p>
         </div>
-    </main>
-
-    <footer>
-        <div class="container">
-            <p>&copy; 2025 Niklas Haas. All rights reserved.</p>
-        </div>
-    </footer>
-
-    <script>
-        setupThemeSwitcher();
-    </script>
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,34 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Niklas Haas - Consulting</title>
-    <meta name="description" content="IT consulting specializing in multimedia processing, SIMD, color management, HDR, and performance optimization. Expert in FFmpeg, libplacebo, VLC, and mpv.">
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <script src="js/theme-switcher.js"></script>
-    <script>initTheme();</script>
-</head>
-<body>
-    <header>
-        <nav class="container">
-            <div class="logo">Haas Consulting</div>
-            <ul class="nav-links">
-                <li><a href="#about">About</a></li>
-                <li><a href="#services">Services</a></li>
-                <li><a href="#skills">Skills</a></li>
-                <li><a href="#projects">Projects</a></li>
-                <li><a href="#contact">Contact</a></li>
-                <li><a href="#" class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-                    <span class="material-icons theme-icon">brightness_4</span>
-                </a></li>
-            </ul>
-        </nav>
-    </header>
+---
+layout: default
+title: Consulting
+description: IT consulting specializing in multimedia processing, SIMD, color management, HDR, and performance optimization. Expert in FFmpeg, libplacebo, VLC, and mpv.
+---
 
-    <main>
         <section id="hero">
             <div class="container">
                 <h1>Haas Consulting</h1>
@@ -336,7 +311,7 @@
                     <!-- Placeholder for testimonials -->
                     <div class="testimonial-card placeholder">
                         <p class="testimonial-text">
-                            "We contracted Niklas through ffmpeg’s development mailing list to improve the performance of ffmpeg’s ITU
+                            "We contracted Niklas through ffmpeg's development mailing list to improve the performance of ffmpeg's ITU
                             1770 filter. He was a joy to work with: fast, concise, and precise communication around both technical &
                             contractual matters, quick turnaround, fair rates, and first-rate C/assembly skills. Looking forward to our next
                             opportunities for working together!"
@@ -398,17 +373,3 @@
                 </div>
             </div>
         </section>
-    </main>
-
-    <footer>
-        <div class="container">
-            <p>&copy; 2025 Niklas Haas. All rights reserved.</p>
-            <p><a href="impressum.html">Impressum</a></p>
-        </div>
-    </footer>
-
-    <script>
-        setupThemeSwitcher();
-    </script>
-</body>
-</html>


### PR DESCRIPTION
- Created Jekyll directory structure with _includes and _layouts
- Extracted header and footer into separate includes
- Created default layout that combines header, content, and footer
- Converted index.html and impressum.html to use Jekyll layouts
- Added _config.yml with GitHub Pages configuration
- Added .gitignore for Jekyll build artifacts

This enables easier long-term maintenance with separate header/footer
files and native GitHub Pages deployment without build steps.