### PR TITLE
Add responsive mobile experience with separate projects page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,8 +24,17 @@
                 <li><a href="{{ '/' | relative_url }}#about">About</a></li>
                 <li><a href="{{ '/' | relative_url }}#services">Services</a></li>
                 <li><a href="{{ '/' | relative_url }}#skills">Skills</a></li>
-                <li><a href="{{ '/' | relative_url }}#projects">Projects</a></li>
-                <li><a href="{{ '/' | relative_url }}#publications">Publications</a></li>
+                {% if page.url == '/projects.html' or page.url == '/projects/' %}
+                    <!-- On projects page: simple anchors to scroll within page -->
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#publications">Publications</a></li>
+                {% else %}
+                    <!-- On other pages: dual navigation for desktop/mobile -->
+                    <li class="nav-item-desktop"><a href="{{ '/' | relative_url }}#projects">Projects</a></li>
+                    <li class="nav-item-desktop"><a href="{{ '/' | relative_url }}#publications">Publications</a></li>
+                    <li class="nav-item-mobile"><a href="{{ '/projects.html' | relative_url }}">Projects</a></li>
+                    <li class="nav-item-mobile"><a href="{{ '/projects.html' | relative_url }}#publications">Publications</a></li>
+                {% endif %}
                 <li><a href="{{ '/' | relative_url }}#contact">Contact</a></li>
                 <li><a href="#" class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
                     <span class="material-icons theme-icon">brightness_4</span>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -8,7 +8,8 @@
                 </p>
                 <div class="cta-buttons">
                     <a href="#contact" class="btn btn-primary">Get In Touch</a>
-                    <a href="#projects" class="btn btn-secondary">View Projects</a>
+                    <a href="#projects" class="btn btn-secondary hero-projects-btn-desktop">View Projects</a>
+                    <a href="{{ '/projects.html' | relative_url }}" class="btn btn-secondary hero-projects-btn-mobile">View Projects</a>
                 </div>
             </div>
         </section>

--- a/css/style.css
+++ b/css/style.css
@@ -847,6 +847,47 @@ footer a:hover {
     border-bottom-color: var(--primary-color);
 }
 
+/* Projects CTA Section */
+#projects-cta {
+    background: var(--bg-secondary);
+    padding: 4rem 0;
+    text-align: center;
+}
+
+#projects-cta .cta-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+#projects-cta h2 {
+    color: var(--primary-color);
+    margin-bottom: 1rem;
+}
+
+#projects-cta p {
+    font-size: 1.125rem;
+    color: var(--text-secondary);
+    margin-bottom: 2rem;
+}
+
+/* Responsive Navigation - Desktop (default) */
+.nav-item-mobile {
+    display: none;
+}
+
+.nav-item-desktop {
+    display: list-item;
+}
+
+/* Hero Projects Button - Desktop (default) */
+.hero-projects-btn-mobile {
+    display: none;
+}
+
+.hero-projects-btn-desktop {
+    display: inline-block;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .container {
@@ -867,6 +908,29 @@ footer a:hover {
 
     /* Hide theme toggle on mobile devices - users should use system preference */
     .theme-toggle {
+        display: none;
+    }
+
+    /* Mobile Navigation - show mobile links, hide desktop links */
+    .nav-item-mobile {
+        display: list-item;
+    }
+
+    .nav-item-desktop {
+        display: none;
+    }
+
+    /* Hide Projects and Publications sections on mobile homepage */
+    .desktop-only-sections {
+        display: none;
+    }
+
+    /* Hero Projects Button - show mobile version, hide desktop version */
+    .hero-projects-btn-mobile {
+        display: inline-block;
+    }
+
+    .hero-projects-btn-desktop {
         display: none;
     }
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@ description: IT consulting specializing in multimedia processing, SIMD, color ma
 {% include about.html %}
 {% include services.html %}
 {% include skills.html %}
+<div class="desktop-only-sections">
 {% include projects.html %}
 {% include publications.html %}
+</div>
 {% include testimonials.html %}
 {% include contact.html %}

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Projects & Publications
+description: Selected projects, publications, and conference talks by Niklas Haas - multimedia processing, SIMD optimization, color management, and more.
+---
+
+{% include projects.html %}
+{% include publications.html %}
+
+<section id="projects-cta">
+    <div class="container">
+        <div class="cta-content">
+            <h2>Interested in working together?</h2>
+            <p>Let's discuss how I can help with your multimedia processing, performance optimization, or open source development needs.</p>
+            <div class="cta-buttons">
+                <a href="/#contact" class="btn btn-primary">Get In Touch</a>
+                <a href="/" class="btn btn-secondary">Back to Home</a>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary

This PR implements a responsive solution where:
- **Mobile devices**: Projects and Publications are accessible via a separate `/projects.html` page to prevent excessive scrolling
- **Desktop**: Projects and Publications remain as sections on the main page for a seamless single-page experience
- The solution respects the browser's "request desktop site" preference by using CSS media queries (viewport-based)

## Changes

- ✨ Created `projects.html` - a dedicated page combining both Projects and Publications sections
- 🔀 Implemented dual navigation system:
  - Desktop: Links to `#projects` and `#publications` anchors on index
  - Mobile: Links to `/projects.html` and `/projects.html#publications`
- 📱 Hide Projects/Publications sections from homepage on mobile viewports (≤768px)
- 🎨 Updated hero "View Projects" button to navigate appropriately based on viewport
- 💬 Added contact CTA and "Back to Home" link at the bottom of projects page
- 🎯 All responsive behavior uses CSS media queries (no JavaScript required)

## Test Plan

- [ ] Test on desktop viewport - verify Projects/Publications appear on main page
- [ ] Test on mobile viewport - verify Projects/Publications are hidden from main page
- [ ] Test navigation links work correctly on both viewports
- [ ] Test hero "View Projects" button navigates appropriately
- [ ] Test "request desktop site" toggles behavior correctly
- [ ] Test projects.html page displays correctly with both sections
- [ ] Test contact CTA and back link on projects page

🤖 Generated with [Claude Code](https://claude.com/claude-code)