### PR TITLE
Fix service-note collision with expand button

### DIFF
--- a/_includes/services.html
+++ b/_includes/services.html
@@ -62,17 +62,17 @@
                             </p>
                         </div>
                     </div>
+
+                    <div class="service-note">
+                        <p>
+                            While much of my consulting work has focused on open source multimedia projects,
+                            my experience extends across the broader computing landscape.
+                        </p>
+                    </div>
                 </div>
 
                 <button class="section-expand-btn" data-section="services">
                     Show More <i class="fas fa-chevron-down"></i>
                 </button>
-
-                <div class="service-note">
-                    <p>
-                        While much of my consulting work has focused on open source multimedia projects,
-                        my experience extends across the broader computing landscape.
-                    </p>
-                </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary

Fixes a bug where the `.service-note` element in the Services section collides with the "Show More" button when the section is collapsed.

## Problem

The `.service-note` was positioned outside the `.section-collapsible-wrapper`, meaning it remained visible even when the Services section was collapsed. This caused it to overlap with the expand button.

## Solution

Moved the `.service-note` element inside the `.section-collapsible-wrapper` so it's included in the collapsible content and hidden when the section is collapsed.

## Changes

**Services Section** (`_includes/services.html:66-71`)
- Moved `.service-note` from after the wrapper (line 71-76) to inside it (line 66-71)
- Now properly hidden when section is collapsed

## Before/After

**Before:**
```
<div class="section-collapsible-wrapper">
  <div class="services-grid">...</div>
</div>
<button>Show More</button>
<div class="service-note">...</div>  <!-- ❌ Outside wrapper, causes collision -->
```

**After:**
```
<div class="section-collapsible-wrapper">
  <div class="services-grid">...</div>
  <div class="service-note">...</div>  <!-- ✅ Inside wrapper, collapses properly -->
</div>
<button>Show More</button>
```

## Test Plan

- [ ] Verify service-note is hidden when Services section is collapsed
- [ ] Verify no collision between service-note and "Show More" button
- [ ] Verify service-note is visible when section is expanded
- [ ] Test on mobile/tablet viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)