### PR TITLE
Fix mobile photo section overlapping about text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -454,6 +454,10 @@ h2 {
         grid-template-columns: 1fr;
         gap: 2rem;
     }
+
+    .about-photo {
+        position: static;
+    }
 }
 
 .expertise-card {


### PR DESCRIPTION
## Summary
- Fixes the mobile photo section scrolling behind/over the about text
- Restores the `position: static` rule that was inadvertently removed during container query refactoring

## Details
The recent container query refactoring (PR #37) converted the responsive design from `@media` queries to `@container` queries. During this process, the rule that set `.about-photo` to `position: static` on mobile was accidentally removed.

This caused the photo (which has `position: sticky` on desktop) to remain sticky on mobile and scroll over the about text content, creating an overlap issue.

## Changes
- Added `position: static` to `.about-photo` within the `@container about-section (max-width: 700px)` query

## Test plan
- View the about section on mobile or narrow browser window (< 700px)
- Scroll down through the about text
- Verify the photo stays at the top and doesn't scroll over the text content

🤖 Generated with [Claude Code](https://claude.com/claude-code)