### PR TITLE
Set navigation bar opacity to 90% for both themes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,7 @@
     --bg-secondary: #2b1e39;
     --bg-tertiary: #3e2755;
     --border-color: #553d6f;
-    --header-bg: rgba(10, 6, 18, 0.85);
+    --header-bg: rgba(10, 6, 18, 0.90);
     --hero-gradient-start: #2b1e39;
     --hero-gradient-mid: #0a0612;
     --hero-gradient-end: #2b1e39;
@@ -48,7 +48,7 @@
     --bg-secondary: #f5edf8;
     --bg-tertiary: #e9d5f2;
     --border-color: #d4b8e0;
-    --header-bg: rgba(254, 251, 255, 0.9);
+    --header-bg: rgba(254, 251, 255, 0.90);
     --hero-gradient-start: #f5edf8;
     --hero-gradient-mid: #fae8ff;
     --hero-gradient-end: #f5edf8;


### PR DESCRIPTION
Standardize header transparency at 90% opacity for both dark and light themes to improve readability while maintaining the subtle translucent effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)