### PR TITLE
Swap light and dark themes to make light the default

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,39 +5,8 @@
     box-sizing: border-box;
 }
 
-/* Dark theme (default) - Enhanced Purple/Blue Edition */
+/* Light theme (default) - Pink/Purple Edition */
 :root {
-    --primary-color: #df79fb;
-    --primary-dark: #d346f2;
-    --accent-color: #ba84fd;
-    --secondary-color: #b3a3d5;
-    --text-primary: #f5f3ff;
-    --text-secondary: #ddd6f0;
-    --bg-primary: #0a0612;
-    --bg-secondary: #291e3d;
-    --bg-tertiary: #3b2759;
-    --border-color: #513d73;
-    --header-bg: rgba(10, 6, 18, 0.90);
-    --hero-gradient-start: #120a23;
-    --hero-gradient-mid: #0e081a;
-    --hero-gradient-end: #0a0612;
-    --hero-text-color: #f5f3ff;
-    --gradient-overlay-1: rgba(223, 121, 251, 0.05);
-    --gradient-overlay-2: rgba(186, 132, 253, 0.06);
-    --shimmer-1: rgba(223, 121, 251, 0.07);
-    --shimmer-2: rgba(186, 132, 253, 0.09);
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.6);
-    --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.7);
-    --btn-primary-hover-shadow: 0 10px 25px rgba(223, 121, 251, 0.45), 0 6px 15px rgba(186, 132, 253, 0.25);
-    --btn-secondary-hover-bg: rgba(223, 121, 251, 0.13);
-    --gradient-placeholder: linear-gradient(135deg, rgba(223, 121, 251, 0.24), rgba(186, 132, 253, 0.26));
-    --card-overlay: rgba(186, 132, 253, 0.06);
-}
-
-/* Light theme - Pink/Purple Edition */
-:root[data-theme="light"] {
     --primary-color: #c026d3;
     --primary-dark: #a21caf;
     --accent-color: #a855f7;
@@ -69,23 +38,60 @@
     --talk-gradient-end: #a16207;
 }
 
-/* Light theme specific overrides
-   These override the dark theme's white overlay styling.
-   Dark theme uses white overlays on buttons/tags for brightness,
-   but light theme uses solid colors with white text instead. */
-:root[data-theme="light"] .btn-primary {
-    background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
-    color: white;
+/* Dark theme - Enhanced Purple/Blue Edition */
+:root[data-theme="dark"] {
+    --primary-color: #df79fb;
+    --primary-dark: #d346f2;
+    --accent-color: #ba84fd;
+    --secondary-color: #b3a3d5;
+    --text-primary: #f5f3ff;
+    --text-secondary: #ddd6f0;
+    --bg-primary: #0a0612;
+    --bg-secondary: #291e3d;
+    --bg-tertiary: #3b2759;
+    --border-color: #513d73;
+    --header-bg: rgba(10, 6, 18, 0.90);
+    --hero-gradient-start: #120a23;
+    --hero-gradient-mid: #0e081a;
+    --hero-gradient-end: #0a0612;
+    --hero-text-color: #f5f3ff;
+    --gradient-overlay-1: rgba(223, 121, 251, 0.05);
+    --gradient-overlay-2: rgba(186, 132, 253, 0.06);
+    --shimmer-1: rgba(223, 121, 251, 0.07);
+    --shimmer-2: rgba(186, 132, 253, 0.09);
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.6);
+    --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.7);
+    --btn-primary-hover-shadow: 0 10px 25px rgba(223, 121, 251, 0.45), 0 6px 15px rgba(186, 132, 253, 0.25);
+    --btn-secondary-hover-bg: rgba(223, 121, 251, 0.13);
+    --gradient-placeholder: linear-gradient(135deg, rgba(223, 121, 251, 0.24), rgba(186, 132, 253, 0.26));
+    --card-overlay: rgba(186, 132, 253, 0.06);
 }
 
-:root[data-theme="light"] .publication-type {
-    background: var(--primary-color);
-    color: white;
+/* Dark theme specific overrides
+   These override the light theme's solid color styling.
+   Light theme uses solid colors with white text for buttons/tags,
+   but dark theme uses white overlays on gradients for brightness instead. */
+:root[data-theme="dark"] .btn-primary {
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0.25)),
+        linear-gradient(135deg, var(--primary-color), var(--accent-color));
+    color: #0a0612;
 }
 
-:root[data-theme="light"] .publication-type.talk {
-    background: linear-gradient(135deg, var(--talk-gradient-start), var(--talk-gradient-end));
-    color: white;
+:root[data-theme="dark"] .publication-type {
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.3)),
+        var(--primary-color);
+    color: #0a0612;
+}
+
+:root[data-theme="dark"] .publication-type.talk {
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.4)),
+        linear-gradient(135deg, #fbbf24, #f59e0b);
+    color: #0a0612;
 }
 
 html {
@@ -306,10 +312,8 @@ nav {
 }
 
 .btn-primary {
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0.25)),
-        linear-gradient(135deg, var(--primary-color), var(--accent-color));
-    color: #0a0612;
+    background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+    color: white;
 }
 
 .btn-primary:hover {
@@ -747,10 +751,8 @@ h2 {
 }
 
 .publication-type {
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.3)),
-        var(--primary-color);
-    color: #0a0612;
+    background: var(--primary-color);
+    color: white;
     padding: 0.25rem 0.75rem;
     border-radius: 0.375rem;
     font-size: 0.75rem;
@@ -761,10 +763,8 @@ h2 {
 }
 
 .publication-type.talk {
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.4)),
-        linear-gradient(135deg, #fbbf24, #f59e0b);
-    color: #0a0612;
+    background: linear-gradient(135deg, var(--talk-gradient-start), var(--talk-gradient-end));
+    color: white;
 }
 
 .publication-meta {

--- a/js/theme-switcher.js
+++ b/js/theme-switcher.js
@@ -3,10 +3,10 @@
 
 // Get current system preference
 function getSystemPreference() {
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-        return 'light';
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
     }
-    return 'dark';
+    return 'light';
 }
 
 // Apply theme before page renders to prevent flicker
@@ -43,8 +43,8 @@ function initTheme() {
         }
     }
 
-    if (themeToApply === 'light') {
-        document.documentElement.setAttribute('data-theme', 'light');
+    if (themeToApply === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
     } else {
         document.documentElement.removeAttribute('data-theme');
     }
@@ -65,14 +65,14 @@ function setupThemeSwitcher() {
 
     // Update icon based on current theme
     function updateIcon() {
-        const currentTheme = root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
-        themeIcon.textContent = currentTheme === 'light' ? 'brightness_4' : 'brightness_7';
+        const currentTheme = root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        themeIcon.textContent = currentTheme === 'dark' ? 'brightness_7' : 'brightness_4';
     }
 
     // Apply theme
     function setTheme(theme, isManualChange = false, shouldBroadcast = true) {
-        if (theme === 'light') {
-            root.setAttribute('data-theme', 'light');
+        if (theme === 'dark') {
+            root.setAttribute('data-theme', 'dark');
         } else {
             root.removeAttribute('data-theme');
         }
@@ -93,8 +93,8 @@ function setupThemeSwitcher() {
     // Toggle theme (manual user action)
     function toggleTheme(e) {
         e.preventDefault();
-        const currentTheme = root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        const currentTheme = root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        const newTheme = currentTheme === 'light' ? 'dark' : 'light';
         setTheme(newTheme, true, true);
     }
 
@@ -114,10 +114,10 @@ function setupThemeSwitcher() {
 
     // Listen for system theme changes (live updates)
     if (window.matchMedia) {
-        const mediaQuery = window.matchMedia('(prefers-color-scheme: light)');
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
         mediaQuery.addEventListener('change', (e) => {
-            const newSystemPref = e.matches ? 'light' : 'dark';
+            const newSystemPref = e.matches ? 'dark' : 'light';
             const isManual = localStorage.getItem('themeIsManual') === 'true';
 
             // Update last known system preference


### PR DESCRIPTION
## Summary
- Inverted the theme system so light theme is now the default and dark theme is the opt-in alternative
- Updated CSS variable definitions to swap `:root` (now light) and `:root[data-theme="dark"]` (now dark)
- Updated JavaScript theme logic to prefer light theme when no system preference is detected
- Theme-specific overrides for buttons and publication types now target dark theme instead of light

## Test plan
- [ ] Verify light theme appears by default on fresh browser/incognito window with no system preference
- [ ] Verify dark theme appears when system prefers dark mode
- [ ] Verify theme toggle button works correctly (shows sun icon on light theme, moon icon on dark theme)
- [ ] Verify theme persists across page navigation
- [ ] Verify theme changes sync across multiple tabs
- [ ] Test that buttons and publication tags look correct in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)